### PR TITLE
serialization をインストール

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'androidx.navigation.safeargs.kotlin'
     id 'org.jlleitschuh.gradle.ktlint' version '11.3.2'
     id 'com.google.dagger.hilt.android'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.6.0'
 }
 
 android {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,9 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'
-    implementation 'io.ktor:ktor-client-android:1.6.4'
+    implementation 'io.ktor:ktor-client-android:2.2.4'
+    implementation "io.ktor:ktor-serialization-kotlinx-json:2.2.4"
+    implementation "io.ktor:ktor-client-content-negotiation:2.2.4"
 
     implementation 'io.coil-kt:coil:1.3.2'
 
@@ -70,5 +72,5 @@ dependencies {
     implementation "com.google.dagger:hilt-android:2.44"
     kapt "com.google.dagger:hilt-compiler:2.44"
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,4 +68,6 @@ dependencies {
 
     implementation "com.google.dagger:hilt-android:2.44"
     kapt "com.google.dagger:hilt-compiler:2.44"
+
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0'
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/remote/GitHubSearchResult.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/remote/GitHubSearchResult.kt
@@ -1,0 +1,6 @@
+package jp.co.yumemi.android.code_check.data.remote
+
+@kotlinx.serialization.Serializable
+data class GitHubSearchResult(
+    val items: List<RepoSearchResponse>
+)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/remote/RepoSearchResponse.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/remote/RepoSearchResponse.kt
@@ -1,0 +1,19 @@
+package jp.co.yumemi.android.code_check.data.remote
+
+import kotlinx.serialization.SerialName
+
+@kotlinx.serialization.Serializable
+data class RepoSearchResponse(
+    @SerialName("full_name") val name: String,
+    @SerialName("language") val language: String? = null,
+    @SerialName("stargazers_count") val stargazersCount: Long,
+    @SerialName("watchers_count") val watchersCount: Long,
+    @SerialName("forks_count") val forksCount: Long,
+    @SerialName("open_issues_count") val openIssuesCount: Long,
+    val owner: OwnerResponse?
+) {
+    @kotlinx.serialization.Serializable
+    data class OwnerResponse(
+        @SerialName("avatar_url") val avatarUrl: String
+    )
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/SearchRepositoryImpl.kt
@@ -1,20 +1,24 @@
 package jp.co.yumemi.android.code_check.data.repository
 
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
-import io.ktor.client.statement.HttpResponse
+import jp.co.yumemi.android.code_check.data.remote.GitHubSearchResult
+import jp.co.yumemi.android.code_check.data.remote.RepoSearchResponse
 import jp.co.yumemi.android.code_check.domain.repository.SearchRepository
 import javax.inject.Inject
 
 class SearchRepositoryImpl @Inject constructor(
     private val httpClient: HttpClient
 ) : SearchRepository {
-    override suspend fun searchRepositories(query: String): HttpResponse {
-        return httpClient.get("https://api.github.com/search/repositories") {
-            header("Accept", "application/vnd.github.v3+json")
-            parameter("q", query)
-        }
+    override suspend fun searchRepositories(query: String): List<RepoSearchResponse> {
+        val result: GitHubSearchResult =
+            httpClient.get("https://api.github.com/search/repositories") {
+                header("Accept", "application/vnd.github.v3+json")
+                parameter("q", query)
+            }.body()
+        return result.items
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/NetworkModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/NetworkModule.kt
@@ -6,6 +6,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
 import javax.inject.Singleton
 
 @Module
@@ -15,6 +17,9 @@ object NetworkModule {
     @Singleton
     fun provideKtorHttpClient(): HttpClient {
         return HttpClient(Android) {
+            install(ContentNegotiation) {
+                json()
+            }
         }
     }
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/domain/repository/SearchRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/domain/repository/SearchRepository.kt
@@ -1,7 +1,7 @@
 package jp.co.yumemi.android.code_check.domain.repository
 
-import io.ktor.client.statement.HttpResponse
+import jp.co.yumemi.android.code_check.data.remote.RepoSearchResponse
 
 interface SearchRepository {
-    suspend fun searchRepositories(query: String): HttpResponse
+    suspend fun searchRepositories(query: String): List<RepoSearchResponse>
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/search/SearchViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.call.receive
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -39,7 +40,7 @@ class SearchViewModel @Inject constructor(
                     parameter("q", inputText)
                 }
 
-            val jsonBody = JSONObject(response.receive<String>())
+            val jsonBody = JSONObject(response.body<String>())
             val jsonItems = requireNotNull(jsonBody.optJSONArray("items")) {
                 "'items' is missing or not an array in the response JSON."
             }


### PR DESCRIPTION
## Issue
#1 

## 概要
1.6.4 から `io.ktor:ktor-client-android:2.2.4` にアップグレード

- `io.ktor:ktor-serialization-kotlinx-json:2.2.4`
- `io.ktor:ktor-client-content-negotiation:2.2.4`
- `org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.0`
上記のライブラリのインストール

io.ktor:ktor-client-android と ktor-serialization、io.ktor:ktor-client-content-negotiationの 2 系統は同時に使えなかったため ktor-client-android のバージョンをあげた。
