### PR TITLE
不必要な dependencies を削除

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,12 +46,8 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
 
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
 
     implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
     implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
@@ -65,7 +61,6 @@ dependencies {
     implementation 'io.coil-kt:coil:1.3.2'
 
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.1"
 


### PR DESCRIPTION
## Issue
#2 

## 概要
- recyclerView と constraintLayout は material に含まれているので削除
     - https://github.com/material-components/material-components-android/blob/release-1.4/build.gradle 
- lifecycle-runtime と lifecycle-livedata を使用していないので削除
     -  https://developer.android.com/jetpack/androidx/releases/lifecycle?hl=ja
- androidx.test.ext:junit の削除 