### PR TITLE
リポジトリの検索結果を表示する RecyclerView の子のレイアウトを修正

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/adapters/GitRepositoryListAdapter.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/adapters/GitRepositoryListAdapter.kt
@@ -3,12 +3,15 @@ package jp.co.yumemi.android.code_check.adapters
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import com.google.android.material.imageview.ShapeableImageView
+import com.google.android.material.textview.MaterialTextView
 import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.domain.model.RepositorySearchResult
+import java.text.DecimalFormat
 
 class GitRepositoryListAdapter :
     RecyclerView.Adapter<GitRepositoryListAdapter.GitRepositoryListViewHolder>() {
@@ -55,11 +58,19 @@ class GitRepositoryListAdapter :
     }
 
     override fun onBindViewHolder(holder: GitRepositoryListViewHolder, position: Int) {
+        val decimalFormat = DecimalFormat("#,###.##")
         val item = repositoryItems[position]
-        (holder.itemView.findViewById<TextView>(R.id.repositoryNameView)).text = item.fullName
-        holder.itemView.setOnClickListener {
-            onItemClickListener?.let { click ->
-                click(item)
+        holder.itemView.apply {
+            (findViewById<MaterialTextView>(R.id.repositoryNameView)).text =
+                item.fullName
+            (findViewById<ShapeableImageView>(R.id.avatarUrlImageView)).load(item.avatarUrl)
+            (findViewById<MaterialTextView>(R.id.repositoryStarNumberView)).text =
+                decimalFormat.format(item.stargazersCount)
+            (findViewById<MaterialTextView>(R.id.repositoryLanguageTextView)).text = item.language
+            setOnClickListener {
+                onItemClickListener?.let { click ->
+                    click(item)
+                }
             }
         }
     }

--- a/app/src/main/res/drawable/baseline_circle_24.xml
+++ b/app/src/main/res/drawable/baseline_circle_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2z"/>
+</vector>

--- a/app/src/main/res/drawable/round_star_24.xml
+++ b/app/src/main/res/drawable/round_star_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,17.27l4.15,2.51c0.76,0.46 1.69,-0.22 1.49,-1.08l-1.1,-4.72l3.67,-3.18c0.67,-0.58 0.31,-1.68 -0.57,-1.75l-4.83,-0.41l-1.89,-4.46c-0.34,-0.81 -1.5,-0.81 -1.84,0L9.19,8.63L4.36,9.04c-0.88,0.07 -1.24,1.17 -0.57,1.75l3.67,3.18l-1.1,4.72c-0.2,0.86 0.73,1.54 1.49,1.08L12,17.27z"/>
+</vector>

--- a/app/src/main/res/layout/layout_item.xml
+++ b/app/src/main/res/layout/layout_item.xml
@@ -3,19 +3,98 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/selectableItemBackground">
+    android:background="?attr/selectableItemBackground"
+    android:paddingHorizontal="8dp"
+    android:paddingTop="6dp"
+    android:paddingBottom="12dp">
 
-    <TextView
-        android:id="@+id/repositoryNameView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginVertical="8dp"
-        android:textColor="@color/black"
-        android:textSize="12sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/avatarUrlImageView"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginTop="8dp"
+        android:src="@drawable/jetbrains"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:shapeAppearanceOverlay="@style/RoundedImage" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/ownerLoginNameView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="6dp"
+        android:text="@string/owner_login_placeholder"
+        android:textSize="12sp"
+        app:layout_constraintBottom_toBottomOf="@+id/avatarUrlImageView"
+        app:layout_constraintStart_toEndOf="@+id/avatarUrlImageView"
+        app:layout_constraintTop_toTopOf="@+id/avatarUrlImageView" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/repositoryNameView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="@string/repository_name_placeholder"
+        android:textColor="@color/repository_full_name"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="@+id/avatarUrlImageView"
+        app:layout_constraintTop_toBottomOf="@+id/avatarUrlImageView" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/repositoryDescriptionView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="@string/repository_description_placeholder"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="@+id/repositoryNameView"
+        app:layout_constraintTop_toBottomOf="@+id/repositoryNameView" />
+
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/repositoryStarImageView"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_marginTop="8dp"
+        android:src="@drawable/round_star_24"
+        android:tint="@color/star_bg"
+        app:layout_constraintStart_toStartOf="@+id/repositoryDescriptionView"
+        app:layout_constraintTop_toBottomOf="@+id/repositoryDescriptionView" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/repositoryStarNumberView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:text="@string/repository_star_number_placeholder"
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="@+id/repositoryStarImageView"
+        app:layout_constraintStart_toEndOf="@+id/repositoryStarImageView"
+        app:layout_constraintTop_toTopOf="@+id/repositoryStarImageView" />
+
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/languageCircleImageView"
+        android:layout_width="14dp"
+        android:layout_height="14dp"
+        android:layout_marginStart="8dp"
+        android:src="@drawable/baseline_circle_24"
+        app:layout_constraintBottom_toBottomOf="@+id/repositoryStarImageView"
+        app:layout_constraintStart_toEndOf="@+id/repositoryStarNumberView"
+        app:layout_constraintTop_toTopOf="@+id/repositoryStarImageView" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/repositoryLanguageTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:text="@string/repository_language_placeholder"
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="@+id/languageCircleImageView"
+        app:layout_constraintStart_toEndOf="@+id/languageCircleImageView"
+        app:layout_constraintTop_toTopOf="@+id/languageCircleImageView" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -8,4 +8,6 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="searchview_bg">#FF000000</color>
+    <color name="star_bg">#facc15</color>
+    <color name="repository_full_name">#FFFFFFFF</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,4 +8,6 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="searchview_bg">#FFFFFFFF</color>
+    <color name="star_bg">#f1e05a</color>
+    <color name="repository_full_name">#FF000000</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,9 @@
     <string name="watchers_view_placeholder">38530 watchers</string>
     <string name="forks_view_placeholder">4675 forks</string>
     <string name="open_issues_view_placeholder">131 open issues</string>
+    <string name="repository_name_placeholder">full_name</string>
+    <string name="owner_login_placeholder">owner_login</string>
+    <string name="repository_description_placeholder">repository_description</string>
+    <string name="repository_star_number_placeholder">345</string>
+    <string name="repository_language_placeholder">Kotlin</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -21,4 +21,7 @@
         <item name="boxBackgroundMode">none</item>
     </style>
 
+    <style name="RoundedImage">
+        <item name="cornerSize">8dp</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Issue
#8 

## 概要

リポジトリの検索結果に以下の項目を表示するように変更

- ユーザーのアイコン (owner?.avatarUrl)
- ユーザー名 (owner?.login)
- レポジトリ名 (full_name)
- リポジトリの Description (description)
- スターの数 (stargazers_count)
- 言語 (language)

![aaa](https://github.com/user-attachments/assets/ab62a08e-b4e6-416f-bb47-ca3cdb8c75c4)
