### PR TITLE
Markwon をインストールして README を Markdown で表示する

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,4 +75,6 @@ dependencies {
 
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.0'
     androidTestImplementation "androidx.test:runner:1.2.0"
+
+    implementation 'io.noties.markwon:core:4.6.2'
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/ApplicationModule.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/di/ApplicationModule.kt
@@ -1,0 +1,18 @@
+package jp.co.yumemi.android.code_check.di
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import io.noties.markwon.Markwon
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ApplicationModule {
+    @Provides
+    @Singleton
+    fun provideMarkWon(@ApplicationContext context: Context): Markwon = Markwon.create(context)
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/DetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/DetailFragment.kt
@@ -4,6 +4,7 @@
 package jp.co.yumemi.android.code_check.ui.detail
 
 import android.os.Bundle
+import android.util.Base64
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -11,14 +12,15 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.navArgs
-import coil.load
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
+import io.noties.markwon.Markwon
 import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.databinding.FragmentDetailBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class DetailFragment : Fragment(R.layout.fragment_detail) {
@@ -28,6 +30,9 @@ class DetailFragment : Fragment(R.layout.fragment_detail) {
 
     private var _binding: FragmentDetailBinding? = null
     private val binding get() = _binding!!
+
+    @Inject
+    lateinit var markwon: Markwon
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -40,20 +45,8 @@ class DetailFragment : Fragment(R.layout.fragment_detail) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
         val item = args.repoInfo
-        binding.apply {
-            ownerIconView.load(
-                item.avatarUrl
-            )
-            nameView.text = item.fullName
-            languageView.text = item.language
-            starsView.text = getString(R.string.stars_count, item.stargazersCount)
-            watchersView.text = getString(R.string.watchers_count, item.watchersCount)
-            forksView.text = getString(R.string.forks_count, item.forksCount)
-            openIssuesView.text = getString(R.string.open_issues_count, item.openIssuesCount)
-        }
-        fetchREADME(item.fullName)
+        fetchREADME(item.fullName, markwon)
     }
 
     override fun onDestroyView() {
@@ -61,14 +54,16 @@ class DetailFragment : Fragment(R.layout.fragment_detail) {
         _binding = null
     }
 
-    private fun fetchREADME(full_name: String) {
+    private fun fetchREADME(full_name: String, markwon: Markwon) {
         viewLifecycleOwner.lifecycleScope.launch {
             val result = withContext(Dispatchers.IO) {
                 viewModel.fetchREADME(full_name)
             }
             result.fold(
                 onSuccess = {
-                    Snackbar.make(requireView(), "README found", Snackbar.LENGTH_LONG).show()
+                    val decodedBytes = Base64.decode(it.content, Base64.DEFAULT)
+                    val rawMarkdown = String(decodedBytes)
+                    markwon.setMarkdown(binding.readmeTextView, rawMarkdown)
                 },
                 onFailure = {
                     Snackbar.make(requireView(), "No README", Snackbar.LENGTH_LONG).show()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/DetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/detail/DetailFragment.kt
@@ -5,6 +5,7 @@ package jp.co.yumemi.android.code_check.ui.detail
 
 import android.os.Bundle
 import android.util.Base64
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -63,10 +64,15 @@ class DetailFragment : Fragment(R.layout.fragment_detail) {
                 onSuccess = {
                     val decodedBytes = Base64.decode(it.content, Base64.DEFAULT)
                     val rawMarkdown = String(decodedBytes)
-                    markwon.setMarkdown(binding.readmeTextView, rawMarkdown)
+                    if (rawMarkdown.isEmpty() || rawMarkdown.isBlank()) {
+                        binding.readmeTextView.text = getString(R.string.readme_placeholder)
+                    } else {
+                        markwon.setMarkdown(binding.readmeTextView, rawMarkdown)
+                    }
                 },
                 onFailure = {
-                    Snackbar.make(requireView(), "No README", Snackbar.LENGTH_LONG).show()
+                    Snackbar.make(requireView(), it.message.toString(), Snackbar.LENGTH_LONG).show()
+                    Log.e("Error to fetch README: ", it.message.toString())
                 }
             )
         }

--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -1,108 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:padding="8dp">
 
-    <ImageView
-        android:id="@+id/ownerIconView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_margin="16dp"
-        android:contentDescription="@null"
-        android:src="@drawable/jetbrains"
-        app:layout_constraintDimensionRatio="1:1"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_max="240dp" />
-
-    <TextView
-        android:id="@+id/nameView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:text="JetBrains/kotlin"
-        android:textColor="@color/black"
-        android:textSize="18sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/ownerIconView" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/centerGuid"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.5" />
-
-    <TextView
-        android:id="@+id/languageView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="8dp"
-        android:text="Written in Kotlin"
-        android:textColor="@color/black"
-        android:textSize="14sp"
-        app:layout_constraintTop_toBottomOf="@id/nameView"
-        tools:ignore="MissingConstraints" />
-
-    <TextView
-        android:id="@+id/starsView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/start_view_placeholder"
-        android:textAlignment="textEnd"
-        android:textColor="@color/black"
-        android:textSize="12sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@id/centerGuid"
-        app:layout_constraintTop_toBottomOf="@id/nameView" />
-
-    <TextView
-        android:id="@+id/watchersView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/watchers_view_placeholder"
-        android:textAlignment="textEnd"
-        android:textColor="@color/black"
-        android:textSize="12sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@id/centerGuid"
-        app:layout_constraintTop_toBottomOf="@id/starsView" />
-
-    <TextView
-        android:id="@+id/forksView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/forks_view_placeholder"
-        android:textAlignment="textEnd"
-        android:textColor="@color/black"
-        android:textSize="12sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintLeft_toLeftOf="@id/centerGuid"
-        app:layout_constraintTop_toBottomOf="@id/watchersView" />
-
-    <TextView
-        android:id="@+id/openIssuesView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/open_issues_view_placeholder"
-        android:textAlignment="textEnd"
-        android:textColor="@color/black"
-        android:textSize="12sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@id/centerGuid"
-        app:layout_constraintTop_toBottomOf="@id/forksView" />
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/readmeTextView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="8dp">
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/readmeTextView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -10,4 +10,5 @@
     <color name="searchview_bg">#FF000000</color>
     <color name="star_bg">#facc15</color>
     <color name="repository_full_name">#FFFFFFFF</color>
+    <color name="blue">#66B3FF</color>
 </resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -6,7 +6,7 @@
         <item name="colorPrimaryVariant">@color/purple_700</item>
         <item name="colorOnPrimary">@color/black</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondary">@color/blue</item>
         <item name="colorSecondaryVariant">@color/teal_200</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,4 +10,5 @@
     <color name="searchview_bg">#FFFFFFFF</color>
     <color name="star_bg">#f1e05a</color>
     <color name="repository_full_name">#FF000000</color>
+    <color name="blue">#0066CC</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,5 @@
     <string name="repository_description_placeholder">repository_description</string>
     <string name="repository_star_number_placeholder">345</string>
     <string name="repository_language_placeholder">Kotlin</string>
+    <string name="readme_placeholder">README がありません。</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -6,7 +6,7 @@
         <item name="colorPrimaryVariant">@color/purple_700</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondary">@color/blue</item>
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->


### PR DESCRIPTION
## Issue
#9 #35 

## 概要
- [markwon:core:4.6.2](https://github.com/noties/Markwon) をインストール
- README が無い、もしくは空の場合 placeholder text を表示する

![aaac](https://github.com/user-attachments/assets/db62f1a4-e4d8-4053-8b71-a0a9e86f536b)


